### PR TITLE
Support "return" keyword to be used to specify exit status (#12)

### DIFF
--- a/calico/parse.py
+++ b/calico/parse.py
@@ -57,8 +57,7 @@ def get_attribute(node, test_name, names, val_func, val_args, err_message):
     :param val_args: An argument to the validator function
     :param err_message: An error message to shown when validation fails
     """
-    _short, _long = names
-    attr = node.get(_long, node.get(_short))
+    attr = next(filter(lambda i: i is not None, map(node.get, names)), None)
     if attr is not None:
         if val_args is None:
             result = val_func(attr)
@@ -124,7 +123,7 @@ def parse_spec(content):
         (
             "exits",
             {
-                "names": ("x", "exit"),
+                "names": ("x", "exit", "return"),
                 "val_func": isinstance,
                 "val_args": int,
                 "err_message": "%s: Exit status value must be an integer",

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -328,9 +328,14 @@ prompts- you can define variables in the special ``_define`` section:
 
 .. note::
 
+   Although not mentioned in the tutorial, you can also use the ``return``
+   keyword instead of ``exit``.
+
+.. note::
+
    To make the specification file shorter, you can use the following
    shortcuts for the keywords: ``r`` for ``run``, ``e`` for ``expect``,
-   ``s`` for ``send``, ``x`` for ``exit``, ``b`` for ``blocker``,
+   ``s`` for ``send``, ``x`` for ``exit`` or ``return``, ``b`` for ``blocker``,
    ``v`` for ``visible``, ``p`` for ``points``.
 
 Jailing tests

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -79,6 +79,16 @@ def test_case_default_exit_status_should_be_zerd():
     assert runner["c1"].exits == 0
 
 
+def test_case_return_keyword_should_be_ok_for_exit_status():
+    source = """
+          - c1:
+              run: "false"
+              return: 1
+        """
+    runner = parse_spec(source)
+    assert runner["c1"].exits == 1
+
+
 def test_case_integer_exit_status_should_be_ok():
     source = """
       - c1:


### PR DESCRIPTION
* Allow "return" keyword to be used to specify exit status

* Add test for checking "return" keyword

* Update docs to mention "return" keyword